### PR TITLE
Fixed issues in quickstart

### DIFF
--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -204,8 +204,9 @@ The script can be run from the root of the ledger folder, passing the input file
 
 ## Agents
 
-...
+Coming soon.
 
 
 ## Next steps
 
+Coming soon.

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -67,7 +67,7 @@ from fetchai.ledger.contract import Contract
 
 api = None
 if api is None:
-    api = LedgerApi(host="127.0.0.1", port=8100)
+    api = LedgerApi(host="127.0.0.1", port=8000)
 
 agent1 = Entity()
 api.sync(api.tokens.wealth(agent1, 200000000))
@@ -100,7 +100,7 @@ endfunction
 
 api = None
 if api is None:
-    api = LedgerApi(host="127.0.0.1", port=8100)
+    api = LedgerApi(host="127.0.0.1", port=8000)
 
 agent1 = Entity()
 api.sync(api.tokens.wealth(agent1, 200000000))


### PR DESCRIPTION
Default port should be 8000 (not 8100), as reported by a newcomer who tried to run through the quickstart tutorial.

Incomplete sections flagged accordingly.