### PR TITLE
Miscellaneous changes

### DIFF
--- a/docs/etch-language/variables.md
+++ b/docs/etch-language/variables.md
@@ -41,7 +41,7 @@ The `UInt256` label will be supplied in a future version.
 `Int32` is the compiler default so you don't need to explicitly declare this type.
 
 !!! Warn
-Negative unsigned integers are dealt with in the same way C++ deals with them. They return a positive wrapped result dependent on size.
+    Negative unsigned integers are dealt with in the same way C++ deals with them. They return a positive wrapped result dependent on size.
 
 Below is a selection of example integer assignations.
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -131,7 +131,7 @@ The implementation is based on the [Etch language](/etch-language), which is als
 
 ### Loading input data
 
-An Etch program needs a `main()` function as its entry point, and that is where all code in this example will reside.
+An Etch program running outside of a ledger environment needs a `main()` function as its entry point, and that is where all code in this example will reside.
 
 Since the input is provided via multiple CSV files, the `main()` function firstly has to check the correct number of files is provided, then load the input data from them:
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -145,7 +145,7 @@ nav:
         - 'Optimiser': 'etch-language/optimiser.md'
         - 'Scaler': 'etch-language/scaler.md'
  #       - 'TrainingPair': 'etch-language/training-pairs.md'
-    - Extending Etch in C++': 'etch-language/extending-etch.md'
+    - Extending Etch in C++: 'etch-language/extending-etch.md'
     - Examples: 
         - 'Fetch logo': 'etch-language/examples/fetch-logo.md'
         - 'Mandelbrot': 'etch-language/examples/mandelbrot.md'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -145,7 +145,7 @@ nav:
         - 'Optimiser': 'etch-language/optimiser.md'
         - 'Scaler': 'etch-language/scaler.md'
  #       - 'TrainingPair': 'etch-language/training-pairs.md'
-    - Extending Etch in C++: 'etch-language/extending-etch.md'
+ #   - Extending Etch in C++: 'etch-language/extending-etch.md'
     - Examples: 
         - 'Fetch logo': 'etch-language/examples/fetch-logo.md'
         - 'Mandelbrot': 'etch-language/examples/mandelbrot.md'


### PR DESCRIPTION
- Fixed indentation of warning so it is formatted as such
- Clarified when is a `main()` function needed in Etch
- Hidden section because it has no content