### PR TITLE
chores: remove incentivized testnet refs from index page

### DIFF
--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -30,7 +30,7 @@
 .parent {
 display: grid;
 grid-template-columns: repeat(3, 1fr);
-grid-template-rows: auto auto 1fr 1fr 1fr auto auto;
+grid-template-rows: auto auto auto auto;
 grid-column-gap: 6px;
 grid-row-gap: 6px;
 color: white;
@@ -48,11 +48,11 @@ color: white;
 	text-align: right;
 	padding-right: 30px;
 }
-.div2 { grid-area: 3 / 1 / 4 / 4; background-color: #80D2C6}
-.div3 { grid-area: 4 / 1 / 5 / 2; background-color: #F0F0F0; height: 260px;}
-.div4 { grid-area: 4 / 2 / 5 / 3; background-color: #F0F0F0; height: 260px;}
-.div5 { grid-area: 4 / 3 / 5 / 4; background-color: #F0F0F0; height: 260px;}
-.div6 { grid-area: 5 / 1 / 6 / 4; margin: 1px solid black; color: #222;}
+/* .div2 { grid-area: 3 / 1 / 4 / 4; background-color: #80D2C6} */
+/* .div3 { grid-area: 4 / 1 / 5 / 2; background-color: #F0F0F0; height: 260px;} */
+.div4 { grid-area: 3 / 1 / 3 / 2; background-color: #F0F0F0; height: 260px; color: #222;}
+.div5 { grid-area: 3 / 2 / 3 / 3; background-color: #F0F0F0; height: 260px; color: #222;}
+.div6 { grid-area: 4 / 1 / 6 / 4; margin: 1px solid black; color: #222;}
 .div7 { grid-area: 6 / 1 / 7 / 4;  margin: 1px solid black; color: #222;}
 .div8 { grid-area: 7 / 1 / 8 / 4;  margin: 1px solid black; color: #222;}
 .div9 { grid-area: 8 / 1 / 9 / 4;  margin: 1px solid black; color: #222;}

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,21 +1,13 @@
-![GitHub contributors](https://img.shields.io/github/contributors-anon/fetchai/docs)
-![GitHub Pipenv locked Python version](https://img.shields.io/github/pipenv/locked/python-version/fetchai/docs)
-<a href="https://github.com/fetchai/docs/workflows/Docs%20sanity%20checks%20and%20tests">
-<img alt="Docs sanity checks and tests" src="https://github.com/fetchai/docs/workflows/Docs%20sanity%20checks%20and%20tests/badge.svg?branch=master">
-</a>
 <div class="parent">
 <div class="div1 grid_item"><h2>Welcome to Fetch.ai developer resources. Let's get started.</h2> </div>
-<div class="div2 grid_item"><h3>Fetch.ai Incentivized testnets are running now</h3>
-    <p><strong>Over a MILLION FET in rewards over the testnet phases!</strong></p>
-    <p>You can learn more about this journey <a href="../i_nets/">here</a>. The current running testnet is Security themed, and you can get part of a substantial reward pool over the coming weeks: <strong>up to a quarter of a MILLION FET in rewards for taking part</strong>. Each themed testnet divides its focus up into different pieces, so there's something for everyone. <a href="../i_nets/quickstart-bw1">Get started now</a>!</p> </div>
-<a href ="https://docs.fetch.ai/i_nets/quickstart-bw1" class="black-link"><div class="div3 grid_item">       <h3>Incentivized Testnet - Beacon World 1</h3>
-      <p>Earn tokens while contributing to the governance and security of our network</p></div></a>
-<a href="https://docs.fetch.ai/aea" class="black-link"><div class="div4 grid_item">       <h3>Developing agents</h3>
-      <p>Speed up the development of Autonomous Economic Agents using our framework</p></div></a>
-<a href="https://docs.fetch.ai/i_nets" class="black-link"><div class="div5 grid_item">       <h3>Getting Ready for mainnet v2</h3>
-      <p>Learn how to use our ledger technologies as we prepare for mainnet v2</p></div></a>
-
-
+<div class="div4 grid_item">       
+  <h3><a href="https://docs.fetch.ai/aea" class="black-link">Developing agents</a></h3>
+  <p>Speed up the development of Autonomous Economic Agents using our framework</p>
+</div>
+<div class="div5 grid_item">
+  <h3><a href="https://docs.fetch.ai/ledger_v2/" class="black-link">Joining our networks</a></h3>
+  <p>Learn how to use our ledger technologies to join our mainnet v2</p>
+</div>
 <div class="div6 grid_item"> <h1>Here to build agents?</h1>
     <ul>
       <li>Learn about the <a href="../aea">concepts</a>.</li>
@@ -43,11 +35,6 @@
     <p>Upgrading from a previous version of the agent framework? Here’s our <a href="https://docs.fetch.ai/aea/upgrading/">helpful guide</a>.</p>
 </div>
 <div class="div9"> </div> 
-</div>
-
-<div class="admonition note">
-  <p class="admonition-title">Updates!</p>
-  <p>Documentation last updated on <strong>June 4th, 2021</strong></p>
 </div>
 
 <br/>


### PR DESCRIPTION
Here's a preview of the change because reading this pretty nice and organized HTML can make eyes bleed:
![image](https://user-images.githubusercontent.com/539524/136052998-f8fb3e5b-b6ed-4b5c-b9f2-2989aa8af0e6.png)
