### PR TITLE
docs: add ledger-explorer submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,7 @@
 [submodule "cosmpy"]
 	path = cosmpy
 	url = https://github.com/fetchai/cosmpy.git
+[submodule "ledger-explorer"]
+	path = ledger-explorer
+	url = git@github.com:fetchai/ledger-explorer
+	branch = master

--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -60,3 +60,7 @@ color: white;
 .black-link{
 	color: black!important;
 }
+
+.task-list-item input {
+	margin: 0;
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -36,6 +36,7 @@ markdown_extensions:
   - admonition
   - pymdownx.superfences
   - pymdownx.highlight
+  - pymdownx.tasklist
   - markdown_include.include:
       base_path: ./colearn/docs
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -20,6 +20,7 @@ nav:
   - Bug Bounty Program: "bug_bounty.md"
   - Apply for $150M Developer Fund: 'https://forms.gle/rLCvg3u7MFEi3gpb8'
   - Ledger: '!include ./ledger/docs/mkdocs.yml'
+  - Ledger Explorer: '!include ./ledger-explorer/mkdocs.yml'
   - Cosmpy: '!include ./cosmpy/mkdocs.yml'
   - AEA Framework: '!include ./aea/mkdocs.yml'
   - Collective Learning: '!include ./colearn/mkdocs.yml'


### PR DESCRIPTION
### Changes
- adds ledger-explorer submodule#223 

_NOTE: the submodule url is using the SSH, instead of HTTPS, because the ledger-explorer repo is currently private._
(It also looks like this means CI/CD needs a deploy key for that repo)

### Dependencies
- [ ] [TBD]()