### PR TITLE
feat: add cookie consent and docs feedback

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -7,8 +7,8 @@ verify_ssl = true
 tox = "==3.25.1"
 
 [packages]
-mkdocs-material = "==8.3.9"
-mkdocs-monorepo-plugin = "==1.0.2"
+mkdocs-material = "==8.4"
+mkdocs-monorepo-plugin = "==1.0.3"
 mkdocs-macros-plugin = "==0.7.0"
 markdown-include = "==0.7.0"
 mkdocs-mermaid-plugin = {editable = true,git = "https://github.com/pugong/mkdocs-mermaid-plugin.git"}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,7 +3,9 @@ site_url: https://docs.fetch.ai/
 site_description: Everything you need to know about Fetch.ai.
 edit_uri: ""
 site_author: developer@fetch.ai
-copyright: Copyright &copy; 2018 - 2022 Fetch.ai # Copyright notice in footer
+copyright: > # Copyright notice in footer + trigger cookie consent settings
+  Copyright &copy; 2018 - 2022 Fetch.ai -
+  <a href="#__consent">Change cookie settings</a>
 
 strict: true
 
@@ -97,6 +99,30 @@ extra:
   analytics:
     provider: google
     property: UA-118969813-3
+    feedback:
+      title: Was this page helpful?
+      ratings:
+        - icon: material/emoticon-happy-outline
+          name: This page was helpful
+          data: 1
+          note: >-
+            Thanks for your feedback!
+        - icon: material/emoticon-sad-outline
+          name: This page could be improved
+          data: 0
+          note: >-
+            Thanks for your feedback! Help us improve this page by
+            <a href="https://github.com/fetchai/docs/issues/new?labels=feedback&template=improve-docs.yml&title=[feedback]+{title}+-+{url}" target="_blank" rel="noopener">reporting what's wrong</a>.
+  consent:
+    title: Cookie consent
+    description: >-
+      We use cookies to recognize your preferences and measure the effectiveness of our 
+      documentation via the feedback widget at the bottom of every docs page.
+      With your consent, you're helping us make this documentation better.
+    actions:
+      - accept
+      - manage
+      - reject
   social:
     - icon: fontawesome/brands/twitter
       link: https://bit.ly/3oDuI3f


### PR DESCRIPTION
This PR adds cookie consent widget and feedback widget (i.e. `Was this page helpful?` at the bottom every page).
These are based on the upstream features in Material for MkDocs. 