### PR TITLE
ci: update python version and cleanup

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -15,10 +15,10 @@ jobs:
           fetch-depth: 0
           submodules: 'recursive'
 
-      - name: Use python 3.7
-        uses: actions/setup-python@v2
+      - name: Use python 3.9
+        uses: actions/setup-python@v4
         with:
-          python-version: '3.7'
+          python-version: '3.9'
 
       - name: Install Dependencies
         run: pip3 install pipenv && pipenv install

--- a/.github/workflows/docs_pr_preview.yml
+++ b/.github/workflows/docs_pr_preview.yml
@@ -1,9 +1,6 @@
 name: Documentation Preview
 
-on:
-  pull_request:
-    branches:
-      - master
+on: pull_request
 
 jobs:
   build:

--- a/.github/workflows/docs_pr_preview.yml
+++ b/.github/workflows/docs_pr_preview.yml
@@ -7,16 +7,16 @@ on:
 
 jobs:
   build:
-    name: Docs Ephemerial Build
+    name: Docs Ephemeral Build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
           submodules: 'recursive'
-      - uses: actions/setup-python@master
+      - uses: actions/setup-python@v4
         with:
-          python-version: '3.7'
+          python-version: '3.9'
       - name: Install dependencies (ubuntu-latest)
         run: |
           sudo apt-get update --fix-missing
@@ -32,7 +32,7 @@ jobs:
           path: site
 
   deploy:
-    name: Docs Ephemerial Deploy
+    name: Docs Ephemeral Deploy
     needs: build
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/docs_staging.yml
+++ b/.github/workflows/docs_staging.yml
@@ -16,10 +16,10 @@ jobs:
           submodules: 'recursive'
 
 
-      - name: Use python 3.7
-        uses: actions/setup-python@v2
+      - name: Use python 3.9
+        uses: actions/setup-python@v4
         with:
-          python-version: '3.7'
+          python-version: '3.9'
 
       - name: Install Dependencies
         run: pip3 install pipenv && pipenv install --skip-lock --clear

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,11 +1,6 @@
 name: Docs sanity checks and tests
 
-on:
-  push:
-    branches:
-      - develop
-      - master
-  pull_request:
+on: pull_request
 
 jobs:
   common_checks:

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -13,12 +13,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v3
         with:
           submodules: 'true'
-      - uses: actions/setup-python@master
+      - uses: actions/setup-python@v4
         with:
-          python-version: 3.7
+          python-version: 3.9
       - name: Install dependencies (ubuntu-latest)
         run: |
           sudo apt-get update --fix-missing


### PR DESCRIPTION
Update CI workflows to use exact actions versions. 
Update CI workflows to use Python 3.9.
Update workflow triggers.